### PR TITLE
feat: custom recipe creation + Edamam recipe search

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -93,6 +93,7 @@ model recipe {
   yield_amount      Decimal?            @db.Decimal(10, 3)
   yield_unit        unit_code?
   created_at        DateTime            @default(now()) @db.Timestamptz(6)
+  is_private        Boolean             @default(false)
   recipe_ingredient recipe_ingredient[]
   recipe_list_item  recipe_list_item[]
   user_recipe       user_recipe[]

--- a/backend/src/config/schema.sql
+++ b/backend/src/config/schema.sql
@@ -148,6 +148,7 @@ CREATE TABLE IF NOT EXISTS recipe (
   image_url    TEXT,
   yield_amount NUMERIC(10,3),
   yield_unit   unit_code,
+  is_private   BOOLEAN       NOT NULL DEFAULT false,
   created_at   TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
   CONSTRAINT fk_recipe_user
     FOREIGN KEY (user_id) REFERENCES app_user(user_id) ON DELETE CASCADE,

--- a/backend/src/controllers/recipeController.js
+++ b/backend/src/controllers/recipeController.js
@@ -1,4 +1,5 @@
 import * as service from "../services/recipeService.js"
+import * as edamam from "../services/edamamService.js"
 
 export const getRecipes = async (req, res) => {
     const search = req.query.search || null
@@ -156,6 +157,62 @@ export const removeRecipeFromUser = async (req, res) => {
     } catch (error) {
         res.status(500).json({ message: error.message || 'Internal server error' })
     }
+}
+
+export const searchEdamam = async (req, res) => {
+  const query = req.query.q || ''
+  const from = parseInt(req.query.from || '0', 10)
+
+  if (!query.trim()) return res.status(200).json([])
+
+  try {
+    const recipes = await edamam.searchRecipes(query, from)
+    res.status(200).json(recipes)
+  } catch (error) {
+    res.status(500).json({ message: error.message || 'Failed to search recipes' })
+  }
+}
+
+const VALID_UNITS = new Set(['count','gram','ounce','pound','milliliter','liter','gallon','cup','tablespoon','teaspoon'])
+
+const sanitizeUnit = (unit) => {
+  if (!unit) return 'count'
+  const lower = unit.toLowerCase().trim()
+  if (VALID_UNITS.has(lower)) return lower
+  // common Edamam aliases
+  const map = { tsp: 'teaspoon', tbsp: 'tablespoon', tablespoons: 'tablespoon', teaspoons: 'teaspoon',
+    cups: 'cup', grams: 'gram', ounces: 'ounce', pounds: 'pound',
+    milliliters: 'milliliter', liters: 'liter', gallons: 'gallon' }
+  return map[lower] || 'count'
+}
+
+export const importEdamam = async (req, res) => {
+  const supabase_uid = req.user.id
+  const { title, image_url, yield_amount, ingredients } = req.body || {}
+
+  if (!title) return res.status(400).json({ message: 'title is required' })
+
+  const sanitizedIngredients = (ingredients || [])
+    .filter((ing) => ing.name?.trim())
+    .map((ing) => ({ ...ing, unit: sanitizeUnit(ing.unit) }))
+
+  const parsedYield = yield_amount ? Number(yield_amount) : null
+  const resolvedYieldUnit = parsedYield ? 'count' : null
+
+  try {
+    const recipe = await service.createRecipe(supabase_uid, {
+      title,
+      image_url: image_url || null,
+      instructions: null,
+      yield_amount: parsedYield,
+      yield_unit: resolvedYieldUnit,
+      is_private: false,
+      ingredients: sanitizedIngredients,
+    })
+    res.status(201).json(recipe)
+  } catch (error) {
+    res.status(500).json({ message: error.message || 'Internal server error' })
+  }
 }
 
 export const makeRecipe = async (req, res) => {

--- a/backend/src/controllers/recipeController.js
+++ b/backend/src/controllers/recipeController.js
@@ -40,19 +40,22 @@ export const getRecipe = async (req, res) => {
 }
 
 export const createRecipe = async (req, res) => {
-    const { title, instructions, image_url, yield_amount, yield_unit } = req.body || {}
+    const supabase_uid = req.user.id
+    const { title, instructions, image_url, yield_amount, yield_unit, is_private, ingredients } = req.body || {}
 
     if (!title) {
         return res.status(400).json({ message: "title is required" })
     }
 
     try {
-        const recipe = await service.createRecipe({
+        const recipe = await service.createRecipe(supabase_uid, {
             title,
             instructions,
             image_url,
             yield_amount,
             yield_unit,
+            is_private: is_private ?? false,
+            ingredients: ingredients || [],
         })
 
         res.status(201).json(recipe)

--- a/backend/src/routes/recipeRoutes.js
+++ b/backend/src/routes/recipeRoutes.js
@@ -9,10 +9,14 @@ import {
     addRecipeToUser,
     removeRecipeFromUser,
     makeRecipe,
+    searchEdamam,
+    importEdamam,
 } from "../controllers/recipeController.js"
 
 const router = Router()
 
+router.get('/edamam', searchEdamam)
+router.post('/edamam/import', importEdamam)
 router.get('/', getRecipes)
 router.get('/user', getUserRecipes)
 router.get('/:id', getRecipe)

--- a/backend/src/services/edamamService.js
+++ b/backend/src/services/edamamService.js
@@ -1,0 +1,50 @@
+const EDAMAM_BASE = 'https://api.edamam.com/api/recipes/v2'
+
+const normalizeHit = ({ recipe }) => {
+  const id = recipe.uri?.split('#recipe_')[1] || null
+  return {
+    edamam_id: id,
+    title: recipe.label,
+    image_url: recipe.image || null,
+    source_url: recipe.url || null,
+    source: recipe.source || null,
+    yield_amount: recipe.yield || null,
+    yield_unit: null,
+    recipe_ingredient: (recipe.ingredients || []).map((ing) => ({
+      ingredient: { name: ing.food },
+      amount: ing.quantity || null,
+      unit: ing.measure || null,
+      display: ing.text,
+    })),
+    ingredient_lines: recipe.ingredientLines || [],
+    diet_labels: recipe.dietLabels || [],
+    health_labels: recipe.healthLabels || [],
+    cuisine_type: recipe.cuisineType || [],
+    meal_type: recipe.mealType || [],
+  }
+}
+
+export const searchRecipes = async (query, from = 0) => {
+  if (!query?.trim()) return []
+
+  const params = new URLSearchParams({
+    type: 'public',
+    q: query.trim(),
+    app_id: process.env.EDAMAM_APP_ID,
+    app_key: process.env.EDAMAM_APP_KEY,
+    from: String(from),
+    to: String(from + 20),
+  })
+
+  const res = await fetch(`${EDAMAM_BASE}?${params}`, {
+    headers: { 'Edamam-Account-User': process.env.EDAMAM_APP_ID },
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`Edamam API error ${res.status}: ${text.slice(0, 200)}`)
+  }
+
+  const data = await res.json()
+  return (data.hits || []).map(normalizeHit)
+}

--- a/backend/src/services/recipeService.js
+++ b/backend/src/services/recipeService.js
@@ -152,9 +152,10 @@ const getPantryItemsForRecipe = async (db, userId, recipe) => {
 }
 
 export const getRecipes = async (search) => {
-    const where = search ? {
-        title: { contains: search, mode: 'insensitive' },
-    } : undefined
+    const where = {
+        is_private: false,
+        ...(search ? { title: { contains: search, mode: 'insensitive' } } : {}),
+    }
 
     return await prisma.recipe.findMany({
         where,
@@ -201,16 +202,45 @@ export const getRecipe = async (supabaseUid, recipeId) => {
     return buildRecipeAvailability(recipe, pantryItems)
 }
 
-export const createRecipe = async (data) => {
-    return await prisma.recipe.create({
-        data: {
-            title: data.title,
-            instructions: data.instructions || null,
-            image_url: data.image_url || null,
-            yield_amount: data.yield_amount || null,
-            yield_unit: data.yield_unit || null,
-        },
-        include: recipeInclude,
+export const createRecipe = async (supabaseUid, data) => {
+    const user_id = await resolveUserId(supabaseUid)
+
+    return await prisma.$transaction(async (tx) => {
+        const recipe = await tx.recipe.create({
+            data: {
+                title: data.title,
+                instructions: data.instructions || null,
+                image_url: data.image_url || null,
+                yield_amount: data.yield_amount || null,
+                yield_unit: data.yield_unit || null,
+                is_private: data.is_private ?? false,
+            },
+        })
+
+        for (const ing of data.ingredients) {
+            const ingredient = await tx.ingredient.upsert({
+                where: { name: ing.name },
+                create: { name: ing.name },
+                update: {},
+            })
+            await tx.recipe_ingredient.create({
+                data: {
+                    recipe_id: recipe.recipe_id,
+                    ingredient_id: ingredient.ingredient_id,
+                    amount: ing.amount || null,
+                    unit: ing.unit,
+                },
+            })
+        }
+
+        await tx.user_recipe.create({
+            data: { user_id, recipe_id: recipe.recipe_id },
+        })
+
+        return tx.recipe.findUnique({
+            where: { recipe_id: recipe.recipe_id },
+            include: recipeInclude,
+        })
     })
 }
 

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -10,6 +10,7 @@ import PantryScreen from './screens/PantryScreen';
 import AddPantryIngredientScreen from './screens/AddPantryIngredientScreen';
 import RecipeScreen from './screens/RecipeScreen';
 import BrowseRecipesScreen from './screens/BrowseRecipesScreen';
+import CreateRecipeScreen from './screens/CreateRecipeScreen';
 import RecipeDetailScreen from './screens/RecipeDetailScreen';
 import LoginScreen from './screens/LoginScreen';
 import SignupScreen from './screens/SignupScreen';
@@ -27,6 +28,7 @@ export default function App() {
 
     const [selectedRecipe, setSelectedRecipe] = useState(null);
     const [browsingRecipes, setBrowsingRecipes] = useState(false);
+    const [creatingRecipe, setCreatingRecipe] = useState(false);
     const [activeScreen, setActiveScreen] = useState('pantry');
     const [addIngredient, setAddIngredient] = useState(null);
 
@@ -105,6 +107,7 @@ export default function App() {
         setSession(null);
         setSelectedRecipe(null);
         setBrowsingRecipes(false);
+        setCreatingRecipe(false);
         setActiveScreen('pantry');
     }
 
@@ -121,6 +124,12 @@ export default function App() {
                             session={session}
                             allowAddToList={browsingRecipes}
                         />
+                    ) : creatingRecipe ? (
+                        <CreateRecipeScreen
+                            session={session}
+                            onCreated={() => setCreatingRecipe(false)}
+                            onCancel={() => setCreatingRecipe(false)}
+                        />
                     ) : browsingRecipes ? (
                         <BrowseRecipesScreen
                             session={session}
@@ -131,6 +140,7 @@ export default function App() {
                         <RecipeScreen
                             session={session}
                             onOpenBrowse={() => setBrowsingRecipes(true)}
+                            onCreateRecipe={() => setCreatingRecipe(true)}
                             onSelectRecipe={setSelectedRecipe}
                         />
                     )}

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -31,10 +31,6 @@
     "web": {
       "favicon": "./assets/favicon.png"
     },
-    "extra": {
-      "eas": {
-        "projectId": "7ba7760e-280d-4ab4-9038-c37d800f13dd"
-      }
-    }
+    "extra": {}
   }
 }

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -5,7 +5,7 @@ console.log(host);
 export const API_URL =
   process.env.EXPO_PUBLIC_APP_ENV === 'production'
     ? 'https://whisk-lznv.onrender.com'
-    : `http://${host}:3000`;
+    : `http://${host}:3001`;
 
 const handleResponse = async (res) => {
   if (res.ok) return res.status === 204 ? null : res.json();
@@ -64,3 +64,9 @@ export const lookupBarcode = (token, barcode) => fetchJson(`/product/${barcode}`
 export const getIngredients = (token) => fetchJson('/ingredient', { token });
 export const deleteIngredient = (token, id) => fetchJson(`/ingredient/${id}`, { method: 'DELETE', token });
 export const updateIngredient = (token, id, name) => fetchJson(`/ingredient/${id}`, { method: 'PATCH', token, body: { name: name.trim() } });
+
+export const searchEdamamRecipes = (token, query, from = 0) =>
+  fetchJson(`/recipe/edamam?q=${encodeURIComponent(query)}&from=${from}`, { token });
+
+export const importEdamamRecipe = (token, payload) =>
+  fetchJson('/recipe/edamam/import', { method: 'POST', token, body: payload });

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -35,6 +35,7 @@ const fetchJson = async (path, { method = 'GET', token, body } = {}) => {
 };
 
 export const getRecipes = (token) => fetchJson('/recipe', { token });
+export const createRecipe = (token, payload) => fetchJson('/recipe', { method: 'POST', token, body: payload });
 export const getUserRecipes = (token, query = '') =>
   fetchJson(`/recipe/user${query ? `?search=${encodeURIComponent(query)}` : ''}`, { token });
 export const getRecipe = (token, id) => fetchJson(`/recipe/${id}`, { token });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "prod:android": "EXPO_PUBLIC_APP_ENV=production expo start --android",
     "prod:ios": "EXPO_PUBLIC_APP_ENV=production expo start --ios",

--- a/frontend/screens/BrowseRecipesScreen.js
+++ b/frontend/screens/BrowseRecipesScreen.js
@@ -1,123 +1,214 @@
-import { useEffect, useState } from 'react';
+import { useState, useRef } from 'react';
 import {
   View,
   FlatList,
+  Text,
+  Image,
   TouchableOpacity,
+  StyleSheet,
   Alert,
 } from 'react-native';
-import RecipeCard from '../components/RecipeCard';
+import { Ionicons } from '@expo/vector-icons';
 import SearchBar from '../components/SearchBar';
 import ErrorMessage from '../components/ErrorMessage';
 import LoadingSpinner from '../components/LoadingSpinner';
 import ScreenHeader from '../components/ScreenHeader';
 import EmptyState from '../components/EmptyState';
-import { getRecipes, addRecipeToUser } from '../lib/api';
-import styles from '../styles/RecipeScreen.styles';
+import { searchEdamamRecipes } from '../lib/api';
+import { COLORS, THEME } from '../styles/colors';
 
 export default function BrowseRecipesScreen({ session, onBack, onSelectRecipe }) {
   const [recipes, setRecipes] = useState([]);
   const [loading, setLoading] = useState(false);
-  const [searchLoading, setSearchLoading] = useState(false);
   const [error, setError] = useState(null);
   const [search, setSearch] = useState('');
+  const [hasSearched, setHasSearched] = useState(false);
+  const debounceTimer = useRef(null);
 
-  const fetchRecipes = async (q = '', { quietSearch = false } = {}) => {
-    const busySetter = quietSearch ? setSearchLoading : setLoading;
-    busySetter(true);
+  const fetchRecipes = async (q) => {
+    if (!q.trim()) {
+      setRecipes([]);
+      setHasSearched(false);
+      return;
+    }
+    setLoading(true);
     setError(null);
+    setHasSearched(true);
     try {
-      const allRecipes = await getRecipes(session.access_token);
-      const filtered = Array.isArray(allRecipes)
-        ? allRecipes.filter((r) =>
-            r.title.toLowerCase().includes(q.toLowerCase())
-          )
-        : [];
-      setRecipes(filtered);
+      const data = await searchEdamamRecipes(session.access_token, q);
+      setRecipes(Array.isArray(data) ? data : []);
     } catch (e) {
       setError(e.message);
       setRecipes([]);
     } finally {
-      busySetter(false);
+      setLoading(false);
     }
   };
 
-  useEffect(() => {
-    fetchRecipes();
-  }, []);
-
   const handleSearch = (text) => {
     setSearch(text);
-    fetchRecipes(text, { quietSearch: true });
-  };
-
-  const handleAdd = (recipeId) => {
-    Alert.alert('Add Recipe', 'Add this recipe to your saved recipes?', [
-      { text: 'Cancel', style: 'cancel' },
-      {
-        text: 'Add',
-        style: 'default',
-        onPress: async () => {
-          try {
-            await addRecipeToUser(session.access_token, recipeId);
-            Alert.alert('Success', 'Recipe added to your list!');
-          } catch (e) {
-            if (e.message.includes('already added')) {
-              Alert.alert('Info', 'This recipe is already in your list.');
-            } else {
-              Alert.alert('Error', 'Failed to add recipe: ' + e.message);
-            }
-          }
-        },
-      },
-    ]);
+    clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => fetchRecipes(text), 500);
   };
 
   return (
     <View style={styles.container}>
       <ScreenHeader title="Browse Recipes" onBack={onBack} />
 
-      <ErrorMessage message={error} />
-
       <SearchBar
         value={search}
         onChangeText={handleSearch}
-        placeholder="Search recipes..."
+        placeholder="Search millions of recipes..."
       />
 
+      <ErrorMessage message={error} />
+
       {loading && <LoadingSpinner />}
-      
-      {!loading && (
+
+      {!loading && !hasSearched && (
+        <EmptyState
+          icon="search-outline"
+          message="Search for any dish, ingredient, or cuisine"
+        />
+      )}
+
+      {!loading && hasSearched && (
         <FlatList
           data={recipes}
-          keyExtractor={(item) => String(item.recipe_id)}
+          keyExtractor={(item) => item.edamam_id}
           renderItem={({ item }) => (
-            <RecipeCard
-              title={item.title}
-              details={[
-                `${item.recipe_ingredient?.length || 0} ingredient${item.recipe_ingredient?.length !== 1 ? 's' : ''}`,
-                item.yield_amount ? `Yield: ${item.yield_amount}${item.yield_unit ? ' ' + item.yield_unit : ''}` : '',
-              ].filter(Boolean)}
+            <TouchableOpacity
+              style={styles.card}
               onPress={() => onSelectRecipe(item)}
-              actions={[
-                {
-                  icon: 'add-circle',
-                  accessibilityLabel: 'Add recipe',
-                  variant: 'success',
-                  onPress: () => handleAdd(item.recipe_id),
-                },
-              ]}
-            />
+              activeOpacity={0.75}
+            >
+              {item.image_url ? (
+                <Image source={{ uri: item.image_url }} style={styles.cardImage} />
+              ) : (
+                <View style={[styles.cardImage, styles.cardImagePlaceholder]}>
+                  <Ionicons name="restaurant-outline" size={28} color={COLORS.textMuted} />
+                </View>
+              )}
+              <View style={styles.cardBody}>
+                <Text style={styles.cardTitle} numberOfLines={2}>{item.title}</Text>
+                <View style={styles.cardMeta}>
+                  {item.source && (
+                    <Text style={styles.cardSource} numberOfLines={1}>{item.source}</Text>
+                  )}
+                  {item.yield_amount && (
+                    <Text style={styles.cardYield}>· {item.yield_amount} servings</Text>
+                  )}
+                </View>
+                {item.meal_type?.length > 0 && (
+                  <View style={styles.tagRow}>
+                    {item.meal_type.slice(0, 2).map((t) => (
+                      <View key={t} style={styles.tag}>
+                        <Text style={styles.tagText}>{t}</Text>
+                      </View>
+                    ))}
+                    {item.diet_labels?.slice(0, 1).map((t) => (
+                      <View key={t} style={[styles.tag, styles.tagGreen]}>
+                        <Text style={[styles.tagText, styles.tagTextGreen]}>{t}</Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+              </View>
+              <Ionicons name="chevron-forward" size={18} color={COLORS.textMuted} style={styles.chevron} />
+            </TouchableOpacity>
           )}
           ListEmptyComponent={
             <EmptyState
-              icon={search ? 'search-outline' : 'compass-outline'}
-              message={
-                search ? 'No recipes match your search.' : 'No recipes available.'
-              }
+              icon="search-outline"
+              message="No recipes found. Try a different search."
             />
           }
+          contentContainerStyle={styles.list}
         />
       )}
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: COLORS.surface,
+    padding: THEME.spacing.lg,
+  },
+  list: {
+    paddingBottom: THEME.spacing.xxl,
+  },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: COLORS.surface,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: THEME.sizing.radius.lg,
+    marginBottom: THEME.spacing.md,
+    overflow: 'hidden',
+    ...THEME.shadow.light,
+  },
+  cardImage: {
+    width: 90,
+    height: 90,
+  },
+  cardImagePlaceholder: {
+    backgroundColor: COLORS.surfaceMuted,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cardBody: {
+    flex: 1,
+    padding: THEME.spacing.md,
+    gap: THEME.spacing.xs,
+  },
+  cardTitle: {
+    fontSize: THEME.typography.fontSize.md,
+    fontWeight: THEME.typography.fontWeight.semibold,
+    color: COLORS.text,
+    lineHeight: 20,
+  },
+  cardMeta: {
+    flexDirection: 'row',
+    gap: THEME.spacing.xs,
+    alignItems: 'center',
+  },
+  cardSource: {
+    fontSize: THEME.typography.fontSize.xs,
+    color: COLORS.textMuted,
+    flex: 1,
+  },
+  cardYield: {
+    fontSize: THEME.typography.fontSize.xs,
+    color: COLORS.textMuted,
+  },
+  tagRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: THEME.spacing.xs,
+    marginTop: 2,
+  },
+  tag: {
+    backgroundColor: COLORS.primarySoft,
+    paddingHorizontal: THEME.spacing.sm,
+    paddingVertical: 2,
+    borderRadius: THEME.sizing.radius.full,
+  },
+  tagGreen: {
+    backgroundColor: COLORS.successSoft,
+  },
+  tagText: {
+    fontSize: THEME.typography.fontSize.xs,
+    color: COLORS.primary,
+    fontWeight: THEME.typography.fontWeight.medium,
+    textTransform: 'capitalize',
+  },
+  tagTextGreen: {
+    color: COLORS.success,
+  },
+  chevron: {
+    marginRight: THEME.spacing.sm,
+  },
+});

--- a/frontend/screens/CreateRecipeScreen.js
+++ b/frontend/screens/CreateRecipeScreen.js
@@ -1,0 +1,179 @@
+import { useState } from 'react';
+import {
+  View, Text, TextInput, TouchableOpacity, ScrollView, Switch, Alert, ActivityIndicator,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Picker } from '@react-native-picker/picker';
+import { createRecipe } from '../lib/api';
+import { COLORS } from '../styles/colors';
+import styles from '../styles/CreateRecipeScreen.styles';
+
+const UNIT_OPTIONS = [
+  'count', 'gram', 'ounce', 'pound', 'milliliter', 'liter', 'gallon', 'cup', 'tablespoon', 'teaspoon',
+];
+
+const emptyIngredient = () => ({ name: '', amount: '', unit: 'count' });
+
+export default function CreateRecipeScreen({ session, onCreated, onCancel }) {
+  const [title, setTitle] = useState('');
+  const [instructions, setInstructions] = useState('');
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [ingredients, setIngredients] = useState([emptyIngredient()]);
+  const [saving, setSaving] = useState(false);
+
+  const addIngredient = () => setIngredients((prev) => [...prev, emptyIngredient()]);
+
+  const removeIngredient = (index) =>
+    setIngredients((prev) => prev.filter((_, i) => i !== index));
+
+  const updateIngredient = (index, field, value) =>
+    setIngredients((prev) =>
+      prev.map((ing, i) => (i === index ? { ...ing, [field]: value } : ing))
+    );
+
+  const handleSave = async () => {
+    if (!title.trim()) {
+      Alert.alert('Title is required');
+      return;
+    }
+
+    const validIngredients = ingredients
+      .filter((ing) => ing.name.trim())
+      .map((ing) => ({
+        name: ing.name.trim(),
+        amount: ing.amount ? Number(ing.amount) : null,
+        unit: ing.unit,
+      }));
+
+    setSaving(true);
+    try {
+      await createRecipe(session.access_token, {
+        title: title.trim(),
+        instructions: instructions.trim() || null,
+        is_private: isPrivate,
+        ingredients: validIngredients,
+      });
+      onCreated();
+    } catch (e) {
+      Alert.alert('Error', e.message || 'Failed to create recipe');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity
+          onPress={onCancel}
+          style={styles.backButton}
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+        >
+          <Ionicons name="chevron-back" size={22} color={COLORS.primary} />
+        </TouchableOpacity>
+        <Text style={styles.title}>Create Recipe</Text>
+      </View>
+
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text style={styles.label}>Title *</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Recipe title"
+          placeholderTextColor={COLORS.placeholder}
+          value={title}
+          onChangeText={setTitle}
+        />
+
+        <Text style={styles.label}>Instructions</Text>
+        <TextInput
+          style={[styles.input, styles.textArea]}
+          placeholder="Step-by-step instructions..."
+          placeholderTextColor={COLORS.placeholder}
+          multiline
+          numberOfLines={4}
+          textAlignVertical="top"
+          value={instructions}
+          onChangeText={setInstructions}
+        />
+
+        <View style={styles.toggleRow}>
+          <View>
+            <Text style={styles.toggleLabel}>Private Recipe</Text>
+            <Text style={styles.hint}>Only visible to you</Text>
+          </View>
+          <Switch
+            value={isPrivate}
+            onValueChange={setIsPrivate}
+            trackColor={{ false: COLORS.border, true: COLORS.primary }}
+            thumbColor={COLORS.surface}
+          />
+        </View>
+
+        <Text style={styles.sectionTitle}>Ingredients</Text>
+
+        {ingredients.map((ing, index) => (
+          <View key={index} style={styles.ingredientRow}>
+            <TextInput
+              style={[styles.input, styles.ingredientName]}
+              placeholder="Name"
+              placeholderTextColor={COLORS.placeholder}
+              value={ing.name}
+              onChangeText={(v) => updateIngredient(index, 'name', v)}
+            />
+            <TextInput
+              style={[styles.input, styles.ingredientAmount]}
+              placeholder="Amt"
+              placeholderTextColor={COLORS.placeholder}
+              keyboardType="numeric"
+              value={ing.amount}
+              onChangeText={(v) => updateIngredient(index, 'amount', v)}
+            />
+            <View style={styles.pickerWrapper}>
+              <Picker
+                selectedValue={ing.unit}
+                onValueChange={(v) => updateIngredient(index, 'unit', v)}
+                style={styles.picker}
+              >
+                {UNIT_OPTIONS.map((u) => (
+                  <Picker.Item key={u} label={u} value={u} />
+                ))}
+              </Picker>
+            </View>
+            {ingredients.length > 1 && (
+              <TouchableOpacity
+                onPress={() => removeIngredient(index)}
+                accessibilityRole="button"
+                accessibilityLabel="Remove ingredient"
+              >
+                <Ionicons name="remove-circle-outline" size={24} color={COLORS.danger} />
+              </TouchableOpacity>
+            )}
+          </View>
+        ))}
+
+        <TouchableOpacity style={styles.addIngredientButton} onPress={addIngredient}>
+          <Ionicons name="add-circle-outline" size={20} color={COLORS.primary} />
+          <Text style={styles.addIngredientText}>Add Ingredient</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.saveButton, saving && styles.saveButtonDisabled]}
+          onPress={handleSave}
+          disabled={saving}
+          accessibilityRole="button"
+          accessibilityLabel="Save recipe"
+        >
+          {saving ? (
+            <ActivityIndicator color={COLORS.buttonText} />
+          ) : (
+            <Text style={styles.saveButtonText}>Save Recipe</Text>
+          )}
+        </TouchableOpacity>
+      </ScrollView>
+    </View>
+  );
+}

--- a/frontend/screens/CreateRecipeScreen.js
+++ b/frontend/screens/CreateRecipeScreen.js
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   View, Text, TextInput, TouchableOpacity, ScrollView, Switch, Alert, ActivityIndicator,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Picker } from '@react-native-picker/picker';
-import { createRecipe } from '../lib/api';
+import { createRecipe, getPantryItems } from '../lib/api';
 import { COLORS } from '../styles/colors';
 import styles from '../styles/CreateRecipeScreen.styles';
 
@@ -20,6 +20,30 @@ export default function CreateRecipeScreen({ session, onCreated, onCancel }) {
   const [isPrivate, setIsPrivate] = useState(false);
   const [ingredients, setIngredients] = useState([emptyIngredient()]);
   const [saving, setSaving] = useState(false);
+  const [pantryItems, setPantryItems] = useState([]);
+
+  useEffect(() => {
+    getPantryItems(session.access_token)
+      .then((data) => setPantryItems(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, []);
+
+  const pantryNameSet = useMemo(() => {
+    const set = new Set();
+    for (const item of pantryItems) {
+      if (item.ingredient?.name) set.add(item.ingredient.name.toLowerCase().trim());
+    }
+    return set;
+  }, [pantryItems]);
+
+  const getPantryStatus = (name) => {
+    const trimmed = name.trim().toLowerCase();
+    if (!trimmed) return null;
+    for (const pantryName of pantryNameSet) {
+      if (pantryName.includes(trimmed) || trimmed.includes(pantryName)) return 'found';
+    }
+    return 'missing';
+  };
 
   const addIngredient = () => setIngredients((prev) => [...prev, emptyIngredient()]);
 
@@ -115,45 +139,75 @@ export default function CreateRecipeScreen({ session, onCreated, onCancel }) {
 
         <Text style={styles.sectionTitle}>Ingredients</Text>
 
-        {ingredients.map((ing, index) => (
-          <View key={index} style={styles.ingredientRow}>
-            <TextInput
-              style={[styles.input, styles.ingredientName]}
-              placeholder="Name"
-              placeholderTextColor={COLORS.placeholder}
-              value={ing.name}
-              onChangeText={(v) => updateIngredient(index, 'name', v)}
-            />
-            <TextInput
-              style={[styles.input, styles.ingredientAmount]}
-              placeholder="Amt"
-              placeholderTextColor={COLORS.placeholder}
-              keyboardType="numeric"
-              value={ing.amount}
-              onChangeText={(v) => updateIngredient(index, 'amount', v)}
-            />
-            <View style={styles.pickerWrapper}>
-              <Picker
-                selectedValue={ing.unit}
-                onValueChange={(v) => updateIngredient(index, 'unit', v)}
-                style={styles.picker}
-              >
-                {UNIT_OPTIONS.map((u) => (
-                  <Picker.Item key={u} label={u} value={u} />
-                ))}
-              </Picker>
+        {ingredients.map((ing, index) => {
+          const status = getPantryStatus(ing.name);
+          return (
+            <View
+              key={index}
+              style={[
+                styles.ingredientCard,
+                status === 'found' && styles.ingredientCardFound,
+                status === 'missing' && styles.ingredientCardMissing,
+              ]}
+            >
+              <View style={styles.ingredientCardHeader}>
+                <TextInput
+                  style={[styles.input, styles.ingredientCardName]}
+                  placeholder="Ingredient name"
+                  placeholderTextColor={COLORS.placeholder}
+                  value={ing.name}
+                  onChangeText={(v) => updateIngredient(index, 'name', v)}
+                />
+                <View style={styles.ingredientStatusBadge}>
+                  {status === 'found' && (
+                    <View style={[styles.statusPill, styles.statusPillFound]}>
+                      <Ionicons name="checkmark-circle" size={14} color={COLORS.success} />
+                      <Text style={[styles.statusPillText, { color: COLORS.success }]}>In pantry</Text>
+                    </View>
+                  )}
+                  {status === 'missing' && (
+                    <View style={[styles.statusPill, styles.statusPillMissing]}>
+                      <Ionicons name="close-circle-outline" size={14} color={COLORS.warning} />
+                      <Text style={[styles.statusPillText, { color: COLORS.warning }]}>Not in pantry</Text>
+                    </View>
+                  )}
+                </View>
+                {ingredients.length > 1 && (
+                  <TouchableOpacity
+                    onPress={() => removeIngredient(index)}
+                    accessibilityRole="button"
+                    accessibilityLabel="Remove ingredient"
+                    style={styles.removeBtn}
+                  >
+                    <Ionicons name="trash-outline" size={18} color={COLORS.danger} />
+                  </TouchableOpacity>
+                )}
+              </View>
+
+              <View style={styles.ingredientCardAmounts}>
+                <TextInput
+                  style={[styles.input, styles.ingredientAmountInput]}
+                  placeholder="Amount"
+                  placeholderTextColor={COLORS.placeholder}
+                  keyboardType="numeric"
+                  value={ing.amount}
+                  onChangeText={(v) => updateIngredient(index, 'amount', v)}
+                />
+                <View style={styles.pickerWrapper}>
+                  <Picker
+                    selectedValue={ing.unit}
+                    onValueChange={(v) => updateIngredient(index, 'unit', v)}
+                    style={styles.picker}
+                  >
+                    {UNIT_OPTIONS.map((u) => (
+                      <Picker.Item key={u} label={u} value={u} />
+                    ))}
+                  </Picker>
+                </View>
+              </View>
             </View>
-            {ingredients.length > 1 && (
-              <TouchableOpacity
-                onPress={() => removeIngredient(index)}
-                accessibilityRole="button"
-                accessibilityLabel="Remove ingredient"
-              >
-                <Ionicons name="remove-circle-outline" size={24} color={COLORS.danger} />
-              </TouchableOpacity>
-            )}
-          </View>
-        ))}
+          );
+        })}
 
         <TouchableOpacity style={styles.addIngredientButton} onPress={addIngredient}>
           <Ionicons name="add-circle-outline" size={20} color={COLORS.primary} />

--- a/frontend/screens/RecipeDetailScreen.js
+++ b/frontend/screens/RecipeDetailScreen.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ScrollView, View, Text, TouchableOpacity, Alert } from 'react-native';
+import { ScrollView, View, Text, TouchableOpacity, Alert, Image } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import AppButton from '../components/AppButton';
 import ErrorMessage from '../components/ErrorMessage';
@@ -8,7 +8,7 @@ import RecipeMissingSummary from '../components/RecipeMissingSummary';
 import RecipeIngredientStatusCard from '../components/RecipeIngredientStatusCard';
 import styles from '../styles/RecipeScreen.styles';
 import { COLORS } from '../styles/colors';
-import { addRecipeToUser, getRecipe, makeRecipe } from '../lib/api';
+import { addRecipeToUser, getRecipe, makeRecipe, importEdamamRecipe } from '../lib/api';
 
 const STATUS_CONFIG = {
   missing: {
@@ -63,8 +63,38 @@ export default function RecipeDetailScreen({
 
   useEffect(() => {
     setRecipeDetail(recipe);
-    loadRecipe();
-  }, [recipe?.recipe_id]);
+    if (!recipe?.edamam_id) loadRecipe();
+  }, [recipe?.recipe_id, recipe?.edamam_id]);
+
+  const handleImportEdamam = () => {
+    Alert.alert('Add Recipe', 'Save this recipe to your list?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Add',
+        onPress: async () => {
+          setActionLoading(true);
+          try {
+            await importEdamamRecipe(session.access_token, {
+              title: currentRecipe.title,
+              image_url: currentRecipe.image_url,
+              yield_amount: currentRecipe.yield_amount,
+              yield_unit: null,
+              ingredients: (currentRecipe.recipe_ingredient || []).map((ing) => ({
+                name: ing.ingredient?.name || '',
+                amount: ing.amount,
+                unit: ing.unit,
+              })),
+            });
+            Alert.alert('Added!', 'Recipe saved to your list.');
+          } catch (e) {
+            Alert.alert('Error', e.message);
+          } finally {
+            setActionLoading(false);
+          }
+        },
+      },
+    ]);
+  };
 
   const handleAddToList = () => {
     Alert.alert('Add Recipe', 'Add this recipe to your saved recipes?', [
@@ -117,6 +147,7 @@ export default function RecipeDetailScreen({
   };
 
   const currentRecipe = recipeDetail || recipe;
+  const isExternal = !!currentRecipe?.edamam_id;
   const summary = currentRecipe?.pantry_status_summary;
 
   return (
@@ -134,9 +165,21 @@ export default function RecipeDetailScreen({
 
       {loading ? <LoadingSpinner /> : null}
 
+      {isExternal && currentRecipe.image_url && (
+        <Image
+          source={{ uri: currentRecipe.image_url }}
+          style={styles.heroImage}
+          resizeMode="cover"
+        />
+      )}
+
       <Text style={styles.recipeName}>{currentRecipe.title}</Text>
 
-      <RecipeMissingSummary summary={summary} statusConfig={STATUS_CONFIG} />
+      {isExternal && currentRecipe.source && (
+        <Text style={styles.recipeSource}>from {currentRecipe.source}</Text>
+      )}
+
+      {!isExternal && <RecipeMissingSummary summary={summary} statusConfig={STATUS_CONFIG} />}
 
       {currentRecipe.yield_amount && (
         <View style={styles.sectionBlock}>
@@ -147,7 +190,16 @@ export default function RecipeDetailScreen({
         </View>
       )}
 
-      {currentRecipe.recipe_ingredient && currentRecipe.recipe_ingredient.length > 0 && (
+      {isExternal && currentRecipe.ingredient_lines?.length > 0 && (
+        <View style={styles.sectionBlock}>
+          <Text style={styles.sectionLabel}>Ingredients</Text>
+          {currentRecipe.ingredient_lines.map((line, i) => (
+            <Text key={i} style={styles.ingredientLine}>· {line}</Text>
+          ))}
+        </View>
+      )}
+
+      {!isExternal && currentRecipe.recipe_ingredient?.length > 0 && (
         <View style={styles.sectionBlock}>
           <Text style={styles.sectionLabel}>Ingredients</Text>
           {currentRecipe.recipe_ingredient.map((ing) => (
@@ -167,21 +219,32 @@ export default function RecipeDetailScreen({
         </View>
       )}
 
-      <AppButton
-        title="Make Recipe"
-        onPress={handleMakeRecipe}
-        disabled={actionLoading || !summary?.can_make_recipe}
-        loading={actionLoading}
-        style={styles.recipeActionButton}
-      />
-
-      {allowAddToList && session ? (
+      {isExternal ? (
         <AppButton
           title="Add to my recipes"
-          onPress={handleAddToList}
+          onPress={handleImportEdamam}
+          loading={actionLoading}
+          disabled={actionLoading}
           style={styles.recipeActionButton}
         />
-      ) : null}
+      ) : (
+        <>
+          <AppButton
+            title="Make Recipe"
+            onPress={handleMakeRecipe}
+            disabled={actionLoading || !summary?.can_make_recipe}
+            loading={actionLoading}
+            style={styles.recipeActionButton}
+          />
+          {allowAddToList && session ? (
+            <AppButton
+              title="Add to my recipes"
+              onPress={handleAddToList}
+              style={styles.recipeActionButton}
+            />
+          ) : null}
+        </>
+      )}
     </ScrollView>
   );
 }

--- a/frontend/screens/RecipeScreen.js
+++ b/frontend/screens/RecipeScreen.js
@@ -3,7 +3,11 @@ import {
   View,
   FlatList,
   Text,
+  Modal,
+  TouchableOpacity,
+  StyleSheet,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import RecipeCard from '../components/RecipeCard';
 import SearchBar from '../components/SearchBar';
 import ErrorMessage from '../components/ErrorMessage';
@@ -13,6 +17,7 @@ import FloatingActionButton from '../components/FloatingActionButton';
 import EmptyState from '../components/EmptyState';
 import { getUserRecipes, removeRecipeFromUser } from '../lib/api';
 import styles from '../styles/RecipeScreen.styles';
+import { COLORS, THEME } from '../styles/colors';
 import { Alert } from 'react-native';
 
 export default function RecipeScreen({ session, onOpenBrowse, onCreateRecipe, onSelectRecipe }) {
@@ -21,6 +26,7 @@ export default function RecipeScreen({ session, onOpenBrowse, onCreateRecipe, on
   const [searchLoading, setSearchLoading] = useState(false);
   const [error, setError] = useState(null);
   const [search, setSearch] = useState('');
+  const [showAddMenu, setShowAddMenu] = useState(false);
 
   const fetchRecipes = async (q = '', { quietSearch = false } = {}) => {
     const busySetter = quietSearch ? setSearchLoading : setLoading;
@@ -112,15 +118,137 @@ export default function RecipeScreen({ session, onOpenBrowse, onCreateRecipe, on
       )}
 
       <FloatingActionButton
-        onPress={() =>
-          Alert.alert('Add Recipe', null, [
-            { text: 'Create Custom Recipe', onPress: onCreateRecipe },
-            { text: 'Browse Recipes', onPress: onOpenBrowse },
-            { text: 'Cancel', style: 'cancel' },
-          ])
-        }
+        onPress={() => setShowAddMenu(true)}
         accessibilityLabel="Add recipe"
       />
+
+      <Modal
+        visible={showAddMenu}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowAddMenu(false)}
+      >
+        <TouchableOpacity
+          style={sheetStyles.overlay}
+          activeOpacity={1}
+          onPress={() => setShowAddMenu(false)}
+        />
+        <View style={sheetStyles.sheet}>
+          <View style={sheetStyles.handle} />
+          <Text style={sheetStyles.sheetTitle}>Add Recipe</Text>
+
+          <TouchableOpacity
+            style={sheetStyles.option}
+            onPress={() => { setShowAddMenu(false); onCreateRecipe(); }}
+            activeOpacity={0.7}
+          >
+            <View style={[sheetStyles.optionIconWrap, { backgroundColor: COLORS.primarySoft }]}>
+              <Ionicons name="create-outline" size={22} color={COLORS.primary} />
+            </View>
+            <View style={sheetStyles.optionBody}>
+              <Text style={sheetStyles.optionTitle}>Create Custom Recipe</Text>
+              <Text style={sheetStyles.optionSubtitle}>Build your own from scratch</Text>
+            </View>
+            <Ionicons name="chevron-forward" size={18} color={COLORS.textMuted} />
+          </TouchableOpacity>
+
+          <View style={sheetStyles.divider} />
+
+          <TouchableOpacity
+            style={sheetStyles.option}
+            onPress={() => { setShowAddMenu(false); onOpenBrowse(); }}
+            activeOpacity={0.7}
+          >
+            <View style={[sheetStyles.optionIconWrap, { backgroundColor: COLORS.successSoft }]}>
+              <Ionicons name="search-outline" size={22} color={COLORS.success} />
+            </View>
+            <View style={sheetStyles.optionBody}>
+              <Text style={sheetStyles.optionTitle}>Browse Recipes</Text>
+              <Text style={sheetStyles.optionSubtitle}>Explore the recipe library</Text>
+            </View>
+            <Ionicons name="chevron-forward" size={18} color={COLORS.textMuted} />
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={sheetStyles.cancelBtn}
+            onPress={() => setShowAddMenu(false)}
+            activeOpacity={0.7}
+          >
+            <Text style={sheetStyles.cancelText}>Cancel</Text>
+          </TouchableOpacity>
+        </View>
+      </Modal>
     </View>
   );
 }
+
+const sheetStyles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: COLORS.overlay,
+  },
+  sheet: {
+    backgroundColor: COLORS.surface,
+    borderTopLeftRadius: THEME.sizing.radius.xxl,
+    borderTopRightRadius: THEME.sizing.radius.xxl,
+    paddingHorizontal: THEME.spacing.lg,
+    paddingBottom: THEME.spacing.xxl + THEME.spacing.lg,
+    paddingTop: THEME.spacing.md,
+    ...THEME.shadow.medium,
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: COLORS.border,
+    alignSelf: 'center',
+    marginBottom: THEME.spacing.lg,
+  },
+  sheetTitle: {
+    fontSize: THEME.typography.fontSize.xl,
+    fontWeight: THEME.typography.fontWeight.bold,
+    color: COLORS.text,
+    marginBottom: THEME.spacing.lg,
+  },
+  option: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: THEME.spacing.md,
+    gap: THEME.spacing.md,
+  },
+  optionIconWrap: {
+    width: 44,
+    height: 44,
+    borderRadius: THEME.sizing.radius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  optionBody: {
+    flex: 1,
+  },
+  optionTitle: {
+    fontSize: THEME.typography.fontSize.md,
+    fontWeight: THEME.typography.fontWeight.semibold,
+    color: COLORS.text,
+  },
+  optionSubtitle: {
+    fontSize: THEME.typography.fontSize.sm,
+    color: COLORS.textSecondary,
+    marginTop: 2,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: COLORS.border,
+    marginVertical: THEME.spacing.xs,
+  },
+  cancelBtn: {
+    marginTop: THEME.spacing.lg,
+    alignItems: 'center',
+    paddingVertical: THEME.spacing.md,
+  },
+  cancelText: {
+    fontSize: THEME.typography.fontSize.base,
+    color: COLORS.textSecondary,
+    fontWeight: THEME.typography.fontWeight.medium,
+  },
+});

--- a/frontend/screens/RecipeScreen.js
+++ b/frontend/screens/RecipeScreen.js
@@ -15,7 +15,7 @@ import { getUserRecipes, removeRecipeFromUser } from '../lib/api';
 import styles from '../styles/RecipeScreen.styles';
 import { Alert } from 'react-native';
 
-export default function RecipeScreen({ session, onOpenBrowse, onSelectRecipe }) {
+export default function RecipeScreen({ session, onOpenBrowse, onCreateRecipe, onSelectRecipe }) {
   const [recipes, setRecipes] = useState([]);
   const [loading, setLoading] = useState(false);
   const [searchLoading, setSearchLoading] = useState(false);
@@ -112,8 +112,14 @@ export default function RecipeScreen({ session, onOpenBrowse, onSelectRecipe }) 
       )}
 
       <FloatingActionButton
-        onPress={onOpenBrowse}
-        accessibilityLabel="Browse recipes to add"
+        onPress={() =>
+          Alert.alert('Add Recipe', null, [
+            { text: 'Create Custom Recipe', onPress: onCreateRecipe },
+            { text: 'Browse Recipes', onPress: onOpenBrowse },
+            { text: 'Cancel', style: 'cancel' },
+          ])
+        }
+        accessibilityLabel="Add recipe"
       />
     </View>
   );

--- a/frontend/styles/CreateRecipeScreen.styles.js
+++ b/frontend/styles/CreateRecipeScreen.styles.js
@@ -73,22 +73,67 @@ export default StyleSheet.create({
     marginTop: THEME.spacing.lg,
     marginBottom: THEME.spacing.sm,
   },
-  ingredientRow: {
+  ingredientCard: {
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: THEME.sizing.radius.lg,
+    padding: THEME.spacing.md,
+    marginBottom: THEME.spacing.md,
+    backgroundColor: COLORS.surfaceMuted,
+  },
+  ingredientCardFound: {
+    borderColor: COLORS.success,
+    backgroundColor: COLORS.successSoft,
+  },
+  ingredientCardMissing: {
+    borderColor: COLORS.border,
+    backgroundColor: COLORS.surface,
+  },
+  ingredientCardHeader: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: THEME.spacing.sm,
     marginBottom: THEME.spacing.sm,
   },
-  ingredientName: {
-    flex: 2,
+  ingredientCardName: {
+    flex: 1,
     marginBottom: 0,
   },
-  ingredientAmount: {
+  ingredientStatusBadge: {
+    flexShrink: 0,
+  },
+  statusPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    paddingHorizontal: THEME.spacing.sm,
+    paddingVertical: 3,
+    borderRadius: THEME.sizing.radius.full,
+  },
+  statusPillFound: {
+    backgroundColor: COLORS.successSoft,
+  },
+  statusPillMissing: {
+    backgroundColor: COLORS.warningSoft,
+  },
+  statusPillText: {
+    fontSize: THEME.typography.fontSize.xs,
+    fontWeight: THEME.typography.fontWeight.medium,
+  },
+  removeBtn: {
+    padding: THEME.spacing.xs,
+  },
+  ingredientCardAmounts: {
+    flexDirection: 'row',
+    gap: THEME.spacing.sm,
+    alignItems: 'center',
+  },
+  ingredientAmountInput: {
     flex: 1,
     marginBottom: 0,
   },
   pickerWrapper: {
-    flex: 1.5,
+    flex: 2,
     borderWidth: 1,
     borderColor: COLORS.border,
     borderRadius: THEME.sizing.radius.md,

--- a/frontend/styles/CreateRecipeScreen.styles.js
+++ b/frontend/styles/CreateRecipeScreen.styles.js
@@ -1,0 +1,131 @@
+import { StyleSheet } from 'react-native';
+import { COLORS, THEME } from './colors';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: COLORS.surface,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: THEME.spacing.lg,
+    paddingBottom: THEME.spacing.sm,
+  },
+  backButton: {
+    paddingRight: THEME.spacing.sm,
+    paddingVertical: THEME.spacing.xs,
+  },
+  title: {
+    fontSize: THEME.typography.fontSize.xxxl,
+    fontWeight: THEME.typography.fontWeight.bold,
+    color: COLORS.text,
+  },
+  scrollContent: {
+    padding: THEME.spacing.lg,
+    paddingBottom: THEME.spacing.xxl * 2,
+  },
+  label: {
+    fontSize: THEME.typography.fontSize.sm,
+    fontWeight: THEME.typography.fontWeight.semibold,
+    color: COLORS.textSecondary,
+    marginBottom: THEME.spacing.xs,
+    marginTop: THEME.spacing.md,
+  },
+  hint: {
+    fontSize: THEME.typography.fontSize.xs,
+    color: COLORS.textMuted,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: THEME.sizing.radius.md,
+    padding: THEME.spacing.md,
+    marginBottom: THEME.spacing.sm,
+    backgroundColor: COLORS.inputFill,
+    color: COLORS.text,
+    fontSize: THEME.typography.fontSize.base,
+  },
+  textArea: {
+    height: 100,
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginVertical: THEME.spacing.md,
+    padding: THEME.spacing.md,
+    backgroundColor: COLORS.surfaceMuted,
+    borderRadius: THEME.sizing.radius.lg,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+  },
+  toggleLabel: {
+    fontSize: THEME.typography.fontSize.base,
+    fontWeight: THEME.typography.fontWeight.medium,
+    color: COLORS.text,
+    marginBottom: THEME.spacing.xs,
+  },
+  sectionTitle: {
+    fontSize: THEME.typography.fontSize.lg,
+    fontWeight: THEME.typography.fontWeight.semibold,
+    color: COLORS.text,
+    marginTop: THEME.spacing.lg,
+    marginBottom: THEME.spacing.sm,
+  },
+  ingredientRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: THEME.spacing.sm,
+    marginBottom: THEME.spacing.sm,
+  },
+  ingredientName: {
+    flex: 2,
+    marginBottom: 0,
+  },
+  ingredientAmount: {
+    flex: 1,
+    marginBottom: 0,
+  },
+  pickerWrapper: {
+    flex: 1.5,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: THEME.sizing.radius.md,
+    backgroundColor: COLORS.inputFill,
+    overflow: 'hidden',
+    justifyContent: 'center',
+  },
+  picker: {
+    height: 48,
+    color: COLORS.text,
+  },
+  addIngredientButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: THEME.spacing.xs,
+    marginVertical: THEME.spacing.md,
+  },
+  addIngredientText: {
+    color: COLORS.primary,
+    fontSize: THEME.typography.fontSize.base,
+    fontWeight: THEME.typography.fontWeight.medium,
+  },
+  saveButton: {
+    backgroundColor: COLORS.primary,
+    padding: THEME.spacing.md,
+    borderRadius: THEME.sizing.radius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: THEME.sizing.buttonHeight,
+    marginTop: THEME.spacing.lg,
+  },
+  saveButtonDisabled: {
+    opacity: 0.6,
+  },
+  saveButtonText: {
+    color: COLORS.buttonText,
+    fontWeight: THEME.typography.fontWeight.bold,
+    fontSize: THEME.typography.fontSize.base,
+  },
+});

--- a/frontend/styles/RecipeScreen.styles.js
+++ b/frontend/styles/RecipeScreen.styles.js
@@ -189,6 +189,24 @@ export default StyleSheet.create({
     color: COLORS.text,
     lineHeight: 20,
   },
+  heroImage: {
+    width: '100%',
+    height: 200,
+    borderRadius: THEME.sizing.radius.xl,
+    marginBottom: THEME.spacing.lg,
+  },
+  recipeSource: {
+    fontSize: THEME.typography.fontSize.sm,
+    color: COLORS.textMuted,
+    marginTop: -THEME.spacing.sm,
+    marginBottom: THEME.spacing.md,
+  },
+  ingredientLine: {
+    fontSize: THEME.typography.fontSize.base,
+    color: COLORS.text,
+    lineHeight: 22,
+    paddingVertical: 2,
+  },
   recipeActionButton: {
     marginTop: THEME.spacing.sm,
   },


### PR DESCRIPTION
feat: add Edamam recipe search, pantry mapping in recipe creation, and UI polish

## Recipe Creation (Custom Recipes)
- Redesigned ingredient rows in CreateRecipeScreen as cards with a two-row layout
  (name + pantry status badge on top, amount + unit picker below) for better readability
- Added live pantry mapping: on mount, fetches the user's pantry items and checks each
  ingredient name against them as the user types (case-insensitive substring match)
- Ingredient cards show a green "In pantry" pill if the ingredient is found in the user's
  pantry, or an amber "Not in pantry" pill if typed but not found, with no indicator for
  empty fields — giving immediate feedback on what you already have
- Replaced minus icon with a trash icon for removing ingredient rows

## Browse Recipes — Edamam Integration
- Replaced the local DB browse screen with a live search against Edamam's 2.3M recipe
  database via the backend proxy (keeps API keys server-side)
- Backend: new GET /recipe/edamam?q=query&from=offset endpoint; proxies to Edamam
  Recipe Search API v2, normalises response into a consistent shape
  (edamam_id, title, image_url, source, yield_amount, recipe_ingredient, ingredient_lines,
  diet_labels, health_labels, cuisine_type, meal_type)
- Backend: new POST /recipe/edamam/import endpoint; saves an Edamam recipe into the local
  DB (creates recipe + ingredients + user_recipe link in one transaction) so the user can
  later use Make Recipe with pantry deduction
- Unit sanitisation on import: maps Edamam measure strings to the unit_code enum
  (e.g. "tsp" to "teaspoon", unknown units to "count"); enforces the chk_yield_valid
  constraint by pairing any non-null yield_amount with yield_unit = "count"
- Browse screen search is debounced (500ms) to avoid firing on every keystroke
- Results display recipe image, title, source site, servings, meal type tags, and diet labels
- "Add to my recipes" on the detail view imports the recipe into the DB and links it to
  the user's account; once saved, Make Recipe and pantry deduction work as normal

## Recipe Detail Screen — Edamam recipe support
- Detects external (Edamam) recipes via edamam_id; skips the getRecipe DB fetch for them
- Shows a hero image, source credit, and plain ingredient lines for Edamam recipes
- Shows "Add to my recipes" instead of "Make Recipe" for external recipes
- DB recipes continue to show pantry status cards, pantry summary, and Make Recipe as before

## Add Recipe Bottom Sheet (UI Polish)
- Replaced the plain system Alert.alert on the Recipes FAB with a custom slide-up Modal
  bottom sheet containing styled option rows with icon badges, titles, subtitles, and
  chevrons — matching the app's visual language
- Options: "Create Custom Recipe" (purple icon) and "Browse Recipes" (green icon)
- Tapping the dark overlay dismisses the sheet

## Backend and Config
- Added EDAMAM_APP_ID and EDAMAM_APP_KEY to backend/.env (not committed)
- New backend/src/services/edamamService.js handles all Edamam API communication
- Removed EAS projectId from frontend/app.json extra block (was routing Expo Go through
  the EAS Update system instead of the local Metro bundler, causing load failures)
- Backend port changed from 3000 to 3001 to avoid conflict with another local process
- Updated frontend API_URL to point to port 3001